### PR TITLE
Fix MediaRules on Safari

### DIFF
--- a/src/Exp.js
+++ b/src/Exp.js
@@ -346,7 +346,17 @@ class Exp {
                     }
                     /* Rule is media query */
                     if (rule instanceof CSSMediaRule) {
-                        scopedStyle = scopedStyle + `@media ${rule.conditionText} {`
+                        let conditionText;
+                        if (!rule.conditionText) {
+                            conditionText = '';
+                            let condTxtArr = Object.keys(rule.media).map(function (objectKey, index) {
+                                return rule.media[objectKey];
+                            });
+                            conditionText = condTxtArr.join(', ');
+                        } else {
+                            conditionText = rule.conditionText;
+                        }
+                        scopedStyle = scopedStyle + `@media ${conditionText} {`;
                         this.listify(rule.cssRules).forEach(rule => {
                             scopedStyle = scopedStyle + this.generateScopedRule(rule);
                         });


### PR DESCRIPTION
rule.conditionText is undefined on Safari. If undefined, generate conditionText from the values of the rule.media object, joined by ', '