### PR TITLE
Fix animation rendering after banner's initialization

### DIFF
--- a/src/Exp.js
+++ b/src/Exp.js
@@ -758,9 +758,9 @@ class Exp {
         if (this.app === null) return;
         if (this.app.classList) {
             this.app.setAttribute(this.bannerId, '');
-            this.app.classList.add(className);
+            setTimeout(()=>{this.app.classList.add(className);}.bind(this), 0);
         } else {
-            this.app.className += ' ' + className;
+            setTimeout(()=>{this.app.className += ' ' + className;}.bind(this), 0);
         }
     }
 

--- a/src/Exp.js
+++ b/src/Exp.js
@@ -758,9 +758,9 @@ class Exp {
         if (this.app === null) return;
         if (this.app.classList) {
             this.app.setAttribute(this.bannerId, '');
-            setTimeout(()=>{this.app.classList.add(className);}.bind(this), 0);
+            window.requestAnimationFrame(()=>{this.app.classList.add(className);}.bind(this), 0);
         } else {
-            setTimeout(()=>{this.app.className += ' ' + className;}.bind(this), 0);
+            window.requestAnimationFrame(()=>{this.app.className += ' ' + className;}.bind(this), 0);
         }
     }
 


### PR DESCRIPTION
After updating CSS yesterday in few projects, banners using current Exp and updated CSS lack initial slide-in animation. CSS works properly, as animations work if subsequently adding or removing the animation class. Likewise, banner is rendered properly, firstly inserted and only then the animation class is added. 
Tried to wrap the lines adding the class in window.requestAnimationFrame(), but that works only sometimes. Wrapping them in function expression or declaration doesn't work. So my guess is that the problem is not with scoping. 
After reading a bit (https://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful), tried wrapping them in setTimeout, and the animation works. 
Suggested fix below. 