### PR TITLE
Bug fix: Change exp-action event listener to arrow function

### DIFF
--- a/src/exp.js
+++ b/src/exp.js
@@ -430,7 +430,7 @@ class Exp {
                 const method = el.getAttribute(`exp-${event}`);
                 /* If exp-action is declared then add appropriate EventListener */
                 if (event === "action") {
-                    el.addEventListener("click", function(e) {
+                    el.addEventListener("click", (e) => {
                         if (this.tracking && this.sdk !== null && this.context !== null) {
                             this.sdk.track("banner", this.getEventProperties("click"));
                         }


### PR DESCRIPTION
Changes:
Change eventListener function to arrow function, so that scope of `this` is whole Exp instance and not function itself.